### PR TITLE
Dietze's fixes to initial forecast and start of Kalman filter

### DIFF
--- a/EnKF.R
+++ b/EnKF.R
@@ -1,0 +1,98 @@
+library(mvtnorm)
+
+EnKF <- function(X.f,Y){
+  
+  ## do analysis
+  mu.f = apply(X.f,1,mean)
+  P.f = var(t(X.f))
+  I = diag(1,36)
+  R = diag(mean(tau_obs),36)
+  #KF Math
+  
+  ## Analysis step: combine previous forecast with observed data
+  obs = !is.na(Y) ## which Y's were observed?
+  if(any(obs)){
+    H <- I[obs,]                                                        ## observation matrix
+    K <- P.f %*% t(H) %*% solve(H%*%P.f%*%t(H) + R[obs,obs])  ## Kalman gain
+    mu.a <- mu.f + K%*%(Y[obs] - H %*% mu.f)              ## update mean
+    P.a <- (1-K %*% H)*P.f                                  ## update covariance
+  } else {
+    ##if there's no data, the posterior is the prior
+    mu.a = mu.f
+    P.a = P.f
+  }
+  
+  X.a = t(rmvnorm(nmc,mu.a,P.a))
+  X.f.new = X.f*NA
+  #note: modeling x on a log scale
+  
+  #iterative forecast will be basically this same code, just different start point that has different posterior (from analysis)
+  for(i in 1:36){  
+    r = out[,grep("r",colnames(out),fixed=TRUE)]
+    dept = out[,grep(paste0("dept[",i,"]"),colnames(out),fixed=TRUE)]
+    tau_add = 1/sqrt(out[,grep("tau_add",colnames(out),fixed=TRUE)])
+    tau_obs = 1/sqrt(out[,grep("tau_obs",colnames(out),fixed=TRUE)])  
+    
+    for (k in 1:nmc){
+      m=rand[k]
+      for(t in start:end){
+        z = X.a[i,k]+ r[m] + dept[m]
+        X.f.new[i,k] = rnorm(1,z,tau_add[m])
+      }
+    }
+  }
+  
+  #in anaysis: choice btw PF and EnKF
+  #PF - likelihood to calculate weights, resample using weights
+  #EnKF- calculate forecast mean and forecast covariance, apply math from KF analysis, sample from that 
+  
+  return(list(X.f = X.f.new,mu.a=mu.a,P.a=P.a))
+}
+
+fx = list()
+for(start in 8:end){
+  print(start)
+  fx[[start]]<- EnKF(xf[start,,],Y[,start])
+}
+
+
+
+
+
+x.new=seq(1,end.forecast,1) # Time vector 
+ci.f.new=array(NA,dim=c(3,end.forecast,36))
+for(i in 1:36){
+  ci.f.new[,,i] <- apply(exp(x[,i,]),1,quantile,c(0.025,0.5,0.975),na.rm=TRUE)
+  plot(ci.f[2,,i],ylim=range(ci.f[,,i],na.rm=TRUE),xlab="Week",ylab="Total Cases",main=colnames(dept.total[i]))
+  ciEnvelope(x.new,ci.f.new[1,,i],ci.f.new[3,,i],col="lightBlue")
+  points(ci.f[2,,i])
+}
+
+time.f.new=seq(1,end.forecast,1)
+for(i in 1:36){
+  ylim=range(cbind(ci[,(1:20)+(i-1)*20],ci.f.new[,,i]),na.rm=TRUE)
+  plot(time.f.new,c(ci[2,(1:20)+(i-1)*20],ci.f.new[2,start:end.forecast,i]),xlab="Time",ylab="Zika Index",main=colnames(dept.total[i]),log="y",ylim=ylim,na.rm=TRUE)
+  #ciEnvelope(time,pi[1,(1:7)+(i-1)*7],pi[3,(1:7)+(i-1)*7],col="lightBlue")
+  ciEnvelope(time.f.new[1:(start-1)],pi[1,(1:20)+(i-1)*20],pi[3,(1:20)+(i-1)*20],col="lightBlue")
+  #ciEnvelope(time.f,c(ci[1,(1:7)+(i-1)*7],ci.f[1,,i]),c(ci[3,(1:7)+(i-1)*7],ci.f[3,,i]),col="Blue")
+  ciEnvelope(time.f.new,ci.f.new[1,,i],ci.f.new[3,,i],col="lightGreen")
+  points(time.f.ew,c(ci[2,(1:20)+(i-1)*20],ci.f[2,start:end.forecast,i]))
+  points(ci.f.new[2,,i],pch="+",col="darkGreen")
+}
+
+time.f=seq(1,end,1)
+for(i in 1:36){
+  ylim=range(cbind(ci[,(1:7)+(i-1)*7],ci.f[,,i]),na.rm=TRUE)
+  plot(time.f.new,c(ci[2,(1:7)+(i-1)*7],ci.f[2,start:end.forecast,i]),xlab="Time",ylab="Zika Index",main=colnames(dept.total[i]),log="y",ylim=ylim,na.rm=TRUE)
+  #ciEnvelope(time,pi[1,(1:7)+(i-1)*7],pi[3,(1:7)+(i-1)*7],col="lightBlue")
+  ciEnvelope(time.f[1:(start-1)],pi[1,(1:7)+(i-1)*7],pi[3,(1:7)+(i-1)*7],col="lightBlue")
+  #ciEnvelope(time.f,c(ci[1,(1:7)+(i-1)*7],ci.f[1,,i]),c(ci[3,(1:7)+(i-1)*7],ci.f[3,,i]),col="Blue")
+  ciEnvelope(time.f,ci.f[1,,i],ci.f[3,,i],col="lightGreen")
+  points(time.f,c(ci[2,(1:7)+(i-1)*7],ci.f[2,start:end,i]))
+  points(ci.f[2,,i],pch="+",col="darkGreen")
+  ciEnvelope(time.f.new,ci.f.new[1,,i],ci.f[3,,i],col="lightGray")
+  points(ci.f.new[2,,i],pch="+",col="darkGreen")
+}
+
+
+

--- a/Kalman_Filter.R
+++ b/Kalman_Filter.R
@@ -1,4 +1,3 @@
-################################################################################
 ## Code from Kalman Filter exercise
 
 KalmanFilter <- function(M,mu0,P0,Q,R,Y){

--- a/get_googletrends_data.R
+++ b/get_googletrends_data.R
@@ -13,9 +13,11 @@ gconnect("zikaforecast@gmail.com","ge585zika")
 
 #Pulling Google trend data for Colombia from September 2015 to present
 ## Change start date to within the last 3 months to get daily updates (using February 1st, 2016 below)
+zika_trend.old=gtrends("zika",geo=c("CO"), start_date="2015-11-01",end_date= "2016-01-31")
 zika_trend=gtrends("zika",geo=c("CO"), start_date= "2016-02-01")
 
-plot(zika_trend)
+zika = rbind(zika_trend.old$trend,zika_trend$trend)
+plot(zika)
 
 # Actual search numbers per day stored in zika_trend$trend
 
@@ -24,7 +26,6 @@ plot(zika_trend)
 # MAILTO=zikaforecast@gmail.com
 # * * 7 * */home/carya/TeamGOATS/get_googletrends_data.R
 
-
 #check if the cron job is running
 file_before= file("GoogleTrendsCronLastUpdate")
 cat("JAG IS UP AND RUNNING",date(),file= file_before, append=TRUE)
@@ -32,3 +33,4 @@ close(file_before)
 
 save.image("googleZika.RData")
 #save
+

--- a/initial_forecast.R
+++ b/initial_forecast.R
@@ -55,33 +55,4 @@ for(i in 1:36){
   Y[i,] = xf[,i,sample.int(nmc,1)]
 }
 
-## do analysis
-mu.f = apply(xf[start,,],1,mean)
-P.f = var(t(xf[start,,]))
-I = diag(1,36)
-R = diag(mean(tau_obs),36)
-#KF Math
-
-## Analysis step: combine previous forecast with observed data
-obs = !is.na(Y[,start]) ## which Y's were observed?
-if(any(obs)){
-  H <- I[obs,]                                                        ## observation matrix
-  K <- P.f %*% t(H) %*% solve(H%*%P.f%*%t(H) + R[obs,obs])  ## Kalman gain
-  mu.a <- mu.f + K%*%(Y[obs,start] - H %*% mu.f)              ## update mean
-  P.a <- (1-K %*% H)*P.f                                  ## update covariance
-} else {
-  ##if there's no data, the posterior is the prior
-  mu.a = mu.f
-  P.a = P.f
-}
-
-
-x = rmvnorm(nmc,mu.a,P.a)
-
-#note: modeling x on a log scale
-
-#iterative forecast will be basically this same code, just different start point that has different posterior (from analysis)
-
-#in anaysis: choice btw PF and EnKF
-  #PF - likelihood to calculate weights, resample using weights
-  #EnKF- calculate forecast mean and forecast covariance, apply math from KF analysis, sample from that 
+### STOP HERE, GO TO ENKF.R ####

--- a/initial_forecast.R
+++ b/initial_forecast.R
@@ -1,18 +1,6 @@
-<<<<<<< HEAD
-i=5 #department (choose whichever has most/best data)
-rand=sample.int(nmc,nmcmc)
-
-for (k in 1:nmn){
-  m=rand[k]
-  xf[t,i,k] = x[time] #setting initial conditions --> first time from MCMC, later from analysis
-  for(t in start:end){
-    z[t,i,k] = xf[t,i,k]+ r[m] + dept[i,m]
-    xf[t,i,k] = rnorm(z[t,i,k],tau_add[m])
-  }
-=======
 #i=1 #department (choose whichever has most/best data)
-
-nmc = 5000 # 1000 to 5000
+library(mvtnorm)
+nmc = 500 # 1000 to 5000
 nmcmc = nrow(out) # = rows in out
 rand=sample.int(nmcmc,nmc)
 start = 8
@@ -21,11 +9,11 @@ end=10
 xf = array(NA,dim = c(end,36,nmc))
 
 for(i in 1:36){  
-x = out[,grep("x[7,1]",colnames(out),fixed=TRUE)] #fix so this "x[7,1]" is not hard coded
+x = out[,grep(paste0("x[7,",i,"]"),colnames(out),fixed=TRUE)] #fix so this "x[7,1]" is not hard coded
 r = out[,grep("r",colnames(out),fixed=TRUE)]
-dept = out[,grep("dept[1]",colnames(out),fixed=TRUE)]
-tau_add = out[,grep("tau_add",colnames(out),fixed=TRUE)]
-  
+dept = out[,grep(paste0("dept[",i,"]"),colnames(out),fixed=TRUE)]
+tau_add = 1/sqrt(out[,grep("tau_add",colnames(out),fixed=TRUE)])
+tau_obs = 1/sqrt(out[,grep("tau_obs",colnames(out),fixed=TRUE)])  
 
    for (k in 1:nmc){
       m=rand[k]
@@ -35,34 +23,60 @@ tau_add = out[,grep("tau_add",colnames(out),fixed=TRUE)]
         xf[t,i,k] = rnorm(1,z,tau_add[m])
         }
    }
-<<<<<<< HEAD
-
-ci = apply(xf[,i,],2,quantile,c(0.025,0.5,0.975),na.rm=TRUE)
-plot(time,ci[2,(start:end)+(i-1)*7],xlab="Time",ylab="Estimated Cases",
-     main=colnames(dept.total[i]),ylim=range(pi[,(start:end)+(i-1)*7]))
-ciEnvelope(time,ci[1,(start:end)+(i-1)*7],ci[3,(start:end)+(i-1)*7],col="Blue")
-points(time,ci[2,(start:end)+(i-1)*7],ylab="Estimated Cases")
->>>>>>> b31a2dd0a0a34fdb1ec822a163f72a2ee15c1d55
-=======
->>>>>>> 8a804b02200127c6e7f0675e74dda04ddf45560c
 }
 
+#data=apply(exp(out[,grep("x",colnames(out))]),2,quantile,c(0.025,0.5,0.975))
 x=seq(1,end,1) # Time vector 
-ci=array(NA,dim=c(3,end,36))
+ci.f=array(NA,dim=c(3,end,36))
 for(i in 1:36){
-ci[,,i] <- apply(exp(xf[,i,]),1,quantile,c(0.025,0.5,0.975),na.rm=TRUE)
-plot(ci[2,,i],ylim=range(ci[,,i],na.rm=TRUE),xlab="Day",ylab="Total Cases",main=colnames(dept.total[i]))
-ciEnvelope(x,ci[1,,i],ci[3,,i],col="lightBlue")
-points(ci[2,,i])
+ci.f[,,i] <- apply(exp(xf[,i,]),1,quantile,c(0.025,0.5,0.975),na.rm=TRUE)
+plot(ci.f[2,,i],ylim=range(ci.f[,,i],na.rm=TRUE),xlab="Week",ylab="Total Cases",main=colnames(dept.total[i]))
+ciEnvelope(x,ci.f[1,,i],ci.f[3,,i],col="lightBlue")
+points(ci.f[2,,i])
+}
+
+time.f=seq(1,end,1)
+for(i in 1:36){
+  ylim=range(cbind(ci[,(1:7)+(i-1)*7],ci.f[,,i]),na.rm=TRUE)
+  plot(time.f,c(ci[2,(1:7)+(i-1)*7],ci.f[2,start:end,i]),xlab="Time",ylab="Zika Index",main=colnames(dept.total[i]),log="y",ylim=ylim,na.rm=TRUE)
+  #ciEnvelope(time,pi[1,(1:7)+(i-1)*7],pi[3,(1:7)+(i-1)*7],col="lightBlue")
+  ciEnvelope(time.f[1:(start-1)],pi[1,(1:7)+(i-1)*7],pi[3,(1:7)+(i-1)*7],col="lightBlue")
+  #ciEnvelope(time.f,c(ci[1,(1:7)+(i-1)*7],ci.f[1,,i]),c(ci[3,(1:7)+(i-1)*7],ci.f[3,,i]),col="Blue")
+  ciEnvelope(time.f,ci.f[1,,i],ci.f[3,,i],col="lightGreen")
+  points(time.f,c(ci[2,(1:7)+(i-1)*7],ci.f[2,start:end,i]))
+  points(ci.f[2,,i],pch="+",col="darkGreen")
 }
 
 #sensitivity and uncertainty 
 
+#pseudodata
+Y = matrix(NA,36,end)
+for(i in 1:36){
+  Y[i,] = xf[,i,sample.int(nmc,1)]
+}
+
 ## do analysis
-muf = mean()
-Pf = var()
-KF Math
-x = sample from rnorm(ne,mua,pa)
+mu.f = apply(xf[start,,],1,mean)
+P.f = var(t(xf[start,,]))
+I = diag(1,36)
+R = diag(mean(tau_obs),36)
+#KF Math
+
+## Analysis step: combine previous forecast with observed data
+obs = !is.na(Y[,start]) ## which Y's were observed?
+if(any(obs)){
+  H <- I[obs,]                                                        ## observation matrix
+  K <- P.f %*% t(H) %*% solve(H%*%P.f%*%t(H) + R[obs,obs])  ## Kalman gain
+  mu.a <- mu.f + K%*%(Y[obs,start] - H %*% mu.f)              ## update mean
+  P.a <- (1-K %*% H)*P.f                                  ## update covariance
+} else {
+  ##if there's no data, the posterior is the prior
+  mu.a = mu.f
+  P.a = P.f
+}
+
+
+x = rmvnorm(nmc,mu.a,P.a)
 
 #note: modeling x on a log scale
 

--- a/model_test_new.R
+++ b/model_test_new.R
@@ -2,8 +2,8 @@ library(rjags)
 
 load("zika.Rdata")
 
-#time = update
-#y = as.integer(total)
+time = update
+y = as.integer(total)
 #plot(time,y,type='l',ylab="Zika Index",lwd=2,log='y')
 
 RandomWalk = "
@@ -63,12 +63,17 @@ j.model   <- jags.model (file = textConnection(RandomWalk),
 jags.out   <- coda.samples (model = j.model,
                             variable.names = c("tau_add","r"),
                             n.iter = 1000)
+
 plot(jags.out)
 
 # Now that the model has converged we'll want to take a much larger sample from the MCMC and include the full vector of X's in the output
 jags.out   <- coda.samples (model = j.model,
                             variable.names = c("x","ypred","tau_add","tau_obs"),
                             n.iter = 10000)
+
+#jags.out   <- coda.samples (model = j.model,
+                            #variable.names = c("x","tau_obs","tau_add","tau_dept","r"),
+                            #n.iter = 10000)
 
 ciEnvelope <- function(x,ylo,yhi,...){
   polygon(cbind(c(x, rev(x), x[1]), c(ylo, rev(yhi),

--- a/model_test_new.R
+++ b/model_test_new.R
@@ -4,11 +4,7 @@ load("zika.RData")
 
 time = update
 y = as.integer(total)
-<<<<<<< HEAD
-#plot(time,y,type='l',ylab="Zika Index",lwd=2,log='y')
-=======
 plot(time,y,type='l',ylab="Zika Index",lwd=2,log='y')
->>>>>>> b31a2dd0a0a34fdb1ec822a163f72a2ee15c1d55
 
 RandomWalk = "
 model{
@@ -92,21 +88,4 @@ points(time,ci[2,(1:7)+(i-1)*7],ylab="Zika Index")
 }
 
 
-
-
-
-
-## Initial forecast
-i=5 #department (choose whichever has most/best data)
-nmc = 5000
-rand=sample.int(nmc,nmcmc)
-
-for (k in 1:nmc){
-  m=rand[k]
-  xf[t,i,k] = x[t,i,k] #setting initial conditions --> first time from MCMC, later from analysis
-  for(t in start:end){
-    z[t,i,k] = xf[t,i,k]+ r[m] + dept[i,m]
-    xf[t,i,k] = rnorm(z[t,i,k],tau_add[m])
-  }
-}
 


### PR DESCRIPTION
Dietze fixed our problem with the confidence intervals in the initial forecast. He also added in the relevant pieces of the Kalman Filter to the end of that script. From here we should just have to plug our psuedodata into the initial forecast to run it further into the future.

***NOTE: the other files included here were just things I had attempted to work on but did not make any changes. Also the Kalman Filter script is just in there for reference, the relevant KF pieces were put into the initial forecast script
